### PR TITLE
modal style hotfix

### DIFF
--- a/src/components/DropZone/DropZone.js
+++ b/src/components/DropZone/DropZone.js
@@ -3,8 +3,15 @@ import AppsContext from '../../contexts/AppsContext';
 import colors from '../../helpers/colors';
 import { Alert } from '@material-ui/lab';
 import Button from '@material-ui/core/Button';
+import { makeStyles } from '@material-ui/core/styles';
 import { createColorMap, convertAppObj } from '../../helpers';
 import '../../styles/DropZone.scss';
+
+const useStyles = makeStyles((theme) => ({
+  outlinedError: {
+    color: theme.palette.error.main,
+  },
+}));
 
 const DropZone = (props) => {
   const { apps, setApps } = useContext(AppsContext);
@@ -58,6 +65,8 @@ const DropZone = (props) => {
     } else setErrorMessage('Please upload a valid file');
   };
 
+  const classes = useStyles();
+
   if (errorMessage) {
     return (
       <div className="container">
@@ -69,13 +78,14 @@ const DropZone = (props) => {
           onDrop={fileDrop}
         >
           <div className="drop-message">
-            <div className="alert">
+            <div>
               <Alert
+                className={classes.outlinedError}
                 onClick={() => {
                   setErrorMessage('');
                 }}
                 action={
-                  <Button color="white" size="medium">
+                  <Button color="inherit" size="medium">
                     X
                   </Button>
                 }

--- a/src/components/flow/ModuleNode.js
+++ b/src/components/flow/ModuleNode.js
@@ -15,6 +15,7 @@ const useStyles = makeStyles((theme) => ({
   },
   paper: {
     backgroundColor: theme.palette.background.paper,
+    color: theme.palette.text.primary,
     border: '2px solid black',
     boxShadow: theme.shadows[5],
     padding: theme.spacing(2, 4, 3),

--- a/src/styles/AppPage.scss
+++ b/src/styles/AppPage.scss
@@ -1,8 +1,6 @@
-* {
-  color: #f5f5f5;
-}
 html {
   background: #242c2e;
+  color: #f5f5f5;
 }
 .homePage {
   background-color: pink;


### PR DESCRIPTION
- Moved the global font color to html tag, instead of *
- Added  `color: theme.palette.text.primary` to `useStyles` on modal to override the global font
- Added `useStyles` to alert message