### PR TITLE
refactor app link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 ### Introduction
 
 Atriom is a developer tool that visualizes component relationships and shared dependencies of Module Federated Applications.
-Generate your application file with Atriom Plugin
 
+- Generate your application file with Atriom Plugin
 - Visit Atriom.com
   - Signup / Login
   - or use Guest Mode

--- a/src/helpers/chartdata.js
+++ b/src/helpers/chartdata.js
@@ -5,7 +5,7 @@ export const createAppList = (apps) => {
   const appList = [];
   for (let i = 0; i < apps.length; i++) {
     appList.push({
-      Header: <Link to={`/app/${apps[i].id}`}>{apps[i].id}</Link>,
+      Header: <Link to={apps[i].data.link}>{apps[i].id}</Link>,
       accessor: `${apps[i].id}`,
     });
   }


### PR DESCRIPTION
- refactored app link in dependency chart to maintain naming convention continuity

`{apps[i].data.link}`